### PR TITLE
Feature/update eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
     'import/order': 'off',
     'import/prefer-default-export': 'off',
     'jsx-a11y/label-has-associated-control': 'off',
+    'no-plusplus': 'off',
     'no-restricted-globals': 'off',
     'no-unexpected-multiline': 'off',
     'no-use-before-define': 'off',


### PR DESCRIPTION
Turned off the rule `no-plusplus` in eslint.

This rule disallows incrementing a variable like this: `i++`

Reason being that if you type `i ++` the semantics are different, but prettier will eat that whitespace anyway if you try it, so I think it's safe to turn off this rule, which is very commonly used and I believe it has been taught intensively through our classes.

https://eslint.org/docs/rules/no-plusplus