### PR TITLE
test: configure end of line settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -6,4 +6,5 @@ module.exports = {
   singleQuote: true,
   arrowParens: 'always',
   trailingComma: 'all',
+  endOfLine: 'lf',
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ script:
 env:
   - DB_HOST="127.0.0.1" DB_PORT="3306" DB_NAME="final_project_db"
     DB_USER="root" DB_PASSWORD=""
+git:
+  autocrlf: input


### PR DESCRIPTION
This should ensure that it is not possible to push any commits with other than "LF" style line endings.

I've set it up according to this:

https://prettier.io/docs/en/options.html#end-of-line

_NOTE: After this has been merged any PC users who may have originally cloned the repo with CRLF line endings will need to clone the repo again._

You can see the type of line endings by editing a file in VSCode and looking at this in the bottom of the window. It should always be CRLF, not LF.

![Screenshot 2020-04-06 20 54 16](https://user-images.githubusercontent.com/1968912/78594559-d2edce00-7848-11ea-828c-a547854282f3.png)
