### PR TITLE
Fix: Add 'next' to error-handling middleware

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -38,7 +38,8 @@ app.use(cors());
 
 app.use(process.env.API_PATH, apiRouter);
 
-app.use((err, req, res) => {
+// eslint-disable-next-line no-unused-vars
+app.use((err, req, res, next) => {
   if (err instanceof HttpError) {
     res.status(err.httpStatus);
     if (err.body) {


### PR DESCRIPTION
Fixes `TypeError: res.sendStatus is not a function` when accessing non-existing routes.

> Define error-handling middleware functions in the same way as other middleware functions, except with four arguments instead of three, specifically with the signature (err, req, res, next)):

https://expressjs.com/en/api.html ("Error-handling middleware")