### PR TITLE
Update 404 page with new structure

### DIFF
--- a/src/client/App.js
+++ b/src/client/App.js
@@ -66,7 +66,7 @@ function App() {
             <PublicRoute exact path="/" component={LoginPage} />
             <PrivateRoute exact path="/dashboard" component={Dashboard} />
 
-            <PublicRoute component={Page404} />
+            <PrivateRoute component={Page404} />
           </Switch>
         </Router>
       </UserRoleContext.Provider>

--- a/src/client/components/logout/logout.component.js
+++ b/src/client/components/logout/logout.component.js
@@ -44,7 +44,7 @@ const PopupModal = ({ closeAction, children, title }) => {
 const LogoutContent = ({ userName, children }) => {
   return (
     <>
-      <div className="content">
+      <div className="modal-content">
         <p>Hi {userName}</p>
         <p>Do you really want to log out?</p>
       </div>

--- a/src/client/components/logout/logout.style.css
+++ b/src/client/components/logout/logout.style.css
@@ -34,7 +34,7 @@
   text-transform: uppercase;
   width: 100%;
 }
-.modal > .content {
+.modal > .modal-content {
   width: 100%;
   padding: 1.2em 0;
   text-align: center;

--- a/src/client/components/side-navigation/sidebar.style.css
+++ b/src/client/components/side-navigation/sidebar.style.css
@@ -2,12 +2,13 @@
   background: var(--light-grey);
   display: flex;
   flex-direction: column;
-  position:fixed;
+  position: fixed;
   text-align: center;
   width: 135px;
   min-height: 100vh;
   border: none;
   box-shadow: var(--debossed-shadow-mini-right);
+  z-index: 1;
 }
 
 .sidebar-wrapper .logo {

--- a/src/client/containers/404-page/404-page.component.js
+++ b/src/client/containers/404-page/404-page.component.js
@@ -1,17 +1,49 @@
-import React from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import SidebarMenu from '../../components/side-navigation/sidebar.component';
+import Logout from '../../components/logout/logout.component';
 import Page404 from '../../components/page404/page404.component';
 import Footer from '../../components/footer/footer.component';
+import { useHistory } from 'react-router-dom';
+import Firebase from '../../firebase/index';
+import UserRoleContext from '../../helpers/UserRoleContext';
+import LoaderAnimation from '../../components/loader-animation/loader-animation.component';
 
 const Page404Container = () => {
-  return (
+  const history = useHistory();
+  const [loading, setLoading] = useState(true);
+  const { userRole, userName } = useContext(UserRoleContext);
+  const [logoutModal, setLogoutModal] = useState(false);
+
+  useEffect(() => {
+    if (userRole && userName) setLoading(false);
+  }, [userRole, userName]);
+  return loading ? (
+    <LoaderAnimation />
+  ) : (
     <>
       <div>
-        <SidebarMenu isActive={false} isUser={true} />
+        <SidebarMenu
+          isActive={false}
+          isVisible={
+            userRole && (userRole === 'admin' || userRole === 'super_admin')
+          }
+          showDashboard={() => history.push('/dashboard')}
+          showBatchDetails={() => history.push('/batch-details')}
+          showAddBatch={() => history.push('/add-batch')}
+          logout={() => setLogoutModal(true)}
+        />
+        <Logout
+          userName={userName}
+          openState={logoutModal}
+          closeAction={() => setLogoutModal(false)}
+          logoutFunc={() => Firebase.signOut()}
+        />
       </div>
-      <div>
-        <Page404 />
-        <Footer />
+      <div className="content">
+        <div className="wrapper">
+          <Page404 />
+          <Footer />
+        </div>
       </div>
     </>
   );

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -31,7 +31,7 @@ button {
   margin-left: 135px;
 }
 .content .wrapper {
-  max-width: 1091px;
+  max-width: 1100px;
   margin: 0 auto;
   position: relative;
   height: 100vh;

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -26,3 +26,13 @@ h2 {
 button {
   cursor: pointer;
 }
+
+.content {
+  margin-left: 135px;
+}
+.content .wrapper {
+  max-width: 1091px;
+  margin: 0 auto;
+  position: relative;
+  height: 100vh;
+}

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -34,5 +34,5 @@ button {
   max-width: 1100px;
   margin: 0 auto;
   position: relative;
-  height: 100vh;
+  height: calc(100vh - 5em);
 }


### PR DESCRIPTION
New sidebar props and logout modal components are added to 404 page. 
Page content is wrapped inside `content` and `wrapper` div's to apply our responsive design logic.
I also added the `content` and `wrapper` style to index.css as we need the same style on each page. As a result of this, I needed to change a class name in logout modal component so it's not affected by the global style.